### PR TITLE
Update GolangCI-lint to v1.51.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION=v1.50.1
+GOLANGCI_VERSION=v1.51.1
 
 lint:
 	golangci-lint run


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/863